### PR TITLE
Batch Bug Fixes

### DIFF
--- a/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
+++ b/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
@@ -105,7 +105,6 @@ public class ScheduleController {
         ScheduleControllerResponse response = new ScheduleControllerResponse();
         response.setSchedules(schedules);
         response.setLastScheduleIndex(scheduler.getLastIndex());
-
         return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
     }
 

--- a/frontend/src/components/events/CourseSelectors.vue
+++ b/frontend/src/components/events/CourseSelectors.vue
@@ -99,13 +99,13 @@
 
       <b-form-row v-show="isOpen">
         <b-col>
-          <b-form-group label-cols="auto" label-cols-md="6" label="Grad classes" label-size="sm">
-            <b-form-checkbox size="sm" v-model="searchFilters.graduateClass"></b-form-checkbox>
+          <b-form-group label-cols="auto" label="Grad classes" label-size="sm">
+            <b-form-checkbox style="padding-top:4px;" size="sm" v-model="searchFilters.graduateClass"></b-form-checkbox>
           </b-form-group>
         </b-col>
         <b-col>
-          <b-form-group label-cols="auto" label-cols-md="6" label="Full classes" label-size="sm">
-            <b-form-checkbox size="sm" v-model="searchFilters.fullClasses"></b-form-checkbox>
+          <b-form-group label-cols="auto" label="Full classes" label-size="sm">
+            <b-form-checkbox style="padding-top:4px;" size="sm" v-model="searchFilters.fullClasses"></b-form-checkbox>
           </b-form-group>
         </b-col>
       </b-form-row>
@@ -137,7 +137,7 @@
             <template v-slot:buttons>
               <font-awesome-icon
                   v-b-tooltip.hover
-                  :title="'Add '+course.fullCourseNumber"
+                  :title="'Add '+course.courseId"
                   icon="plus-square"
                   size="lg"
                   id="addCourse"
@@ -172,8 +172,8 @@ export default {
         pageSize: 10,
         minUnits: '0',
         maxUnits: '5',
-        fullClasses: false,
-        graduateClass: false,
+        fullClasses: true,
+        graduateClass: true,
         selectedRequirement: '',
       },
       currentPage: 1,
@@ -306,7 +306,7 @@ export default {
         minUnits: filters.minUnits,
         maxUnits: filters.maxUnits,
         objLevelCode: filters.graduateClass ? "" : "U",
-        // openSections: !filters.fullClasses,
+        openSections: !filters.fullClasses,
         deptCode: this.currentDepartment,
         areas: this.currentCollege ? filters.selectedRequirement : "",
       }

--- a/frontend/src/components/events/ListItems/CourseListItem.vue
+++ b/frontend/src/components/events/ListItems/CourseListItem.vue
@@ -80,7 +80,7 @@ export default {
      */
     isValid: function() {
       for (let i = 0; i < this.course.classSections.length; i++) {
-        if (this.course.classSections[i].timeLocations.length != 0 && this.course.classSections[i].classClosed?.trim() != "Y" && this.course.classSections[i].courseCancelled?.trim() != "C") {
+        if (this.course.classSections[i].timeLocations?.length != 0 && this.course.classSections[i].classClosed?.trim() != "Y" && this.course.classSections[i].courseCancelled?.trim() != "C") {
           return true;
         }
       }

--- a/frontend/src/components/events/ListItems/CourseListItem.vue
+++ b/frontend/src/components/events/ListItems/CourseListItem.vue
@@ -1,9 +1,10 @@
 <template>
-  <EventListItem
-    :title="course.fullCourseNumber"
+  <EventListItem v-if="isValid"
+    :title="course.courseId"
     :borderColor="borderColor"
     :backgroundColor="backgroundColor"
     :full="full"
+    :randomId="randomId"
   >
     <template v-slot:subtext>
       <strong>{{ displayUnits }}</strong>
@@ -63,15 +64,27 @@ export default {
       // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
       return getBackgroundColor(this.course.courseId.slice(7, 14));
     },
+    /**
+     * Returns whether or not a course is completely full
+     */
     full: function() {
-      let full = true;
-      this.course.classSections.forEach((classSection) => {
-        if (classSection.enrolledTotal < classSection.maxEnroll) {
-          full = false;
+      for (let i = 0; i < this.course.classSections.length; i++) {
+        if (this.course.classSections[i].enrolledTotal < this.course.classSections[i].maxEnroll) {
+          return false;
         }
-        // console.log(classSection.enrolledTotal - classSection.maxEnroll);
-      });
-      return full;
+      }
+      return true;
+    },
+    /**
+     * Returns whether or not a course is cancelled or still TBA
+     */
+    isValid: function() {
+      for (let i = 0; i < this.course.classSections.length; i++) {
+        if (this.course.classSections[i].timeLocations.length != 0 && this.course.classSections[i].classClosed?.trim() != "Y" && this.course.classSections[i].courseCancelled?.trim() != "C") {
+          return true;
+        }
+      }
+      return false;
     },
     /**
      * Returns the requirements fulfilled by the course, grouped by the college.
@@ -97,7 +110,13 @@ export default {
           " units"
         );
       }
-    }
+    },
+    /**
+     * Returns short id used by popovers so that they are only binded to one course.
+     */
+    randomId: function() {
+      return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+    },
   }
 };
 </script>

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -9,7 +9,7 @@
           <strong class="event-name" v-if="full === false">{{ this.title }}</strong>
           <strong class="event-name" v-else>{{ this.title }} (Full)</strong>
         </p>
-        <span class="subtext" :id="'popover'+title">
+        <span class="subtext" :id="'popover'+randomId">
           <small>
               <slot name="subtext">
               </slot>
@@ -21,7 +21,7 @@
           </slot>
       </div>
     </b-list-group-item>
-    <b-popover :target="'popover'+title" triggers="hover" placement="right" boundary="window">
+    <b-popover :target="'popover'+randomId" triggers="hover" placement="right" boundary="window">
       <slot name="popoverContent">
       </slot>
     </b-popover>
@@ -42,6 +42,9 @@ export default {
         },
         full: {
             type: Boolean
+        },
+        randomId: {
+            type: String
         }
     }
 }

--- a/frontend/src/components/schedules/Schedule.vue
+++ b/frontend/src/components/schedules/Schedule.vue
@@ -233,10 +233,10 @@ export default {
           );
         }
       }
-      var totalevents = schedule.classes
+      const totalevents = schedule.classes
         .map(classSectionToFullCalendarEvent)
-        .flat(); //do this function to all of the classes
-      var customevents = schedule.customEvents.map(
+        .flat(2); //do this function to all of the classes
+      const customevents = schedule.customEvents.map(
         classSectionToFullCalendarEvent
       );
 
@@ -251,9 +251,8 @@ export default {
     eventFromEnrollCode: function (enrollcode, course) {
       const section = course.classSections.find(
         (section) => section.enrollCode == enrollcode
-      );
-
-      var titletodisplay = course.fullCourseNumber + ": " + enrollcode;
+      );      
+      const titletodisplay = course.courseId.trim() + ": " + enrollcode;
       const dayInt = {
         MONDAY: 1,
         TUESDAY: 2,
@@ -264,7 +263,7 @@ export default {
       };
       if (section.timeLocations.length == 1) {
         return {
-          title: titletodisplay, //course.fullCourseNumber,
+          title: titletodisplay,
           courseId: course.courseId,
           daysOfWeek: section.timeLocations[0].fullDays.map((a) => dayInt[a]),
           startTime: section.timeLocations[0].beginTime,
@@ -281,10 +280,10 @@ export default {
           textColor: "black",
         };
       } else {
-        var multipleevents = [];
-        var multipletimeandplace = section.timeLocations;
-        var classinfo = {
-          title: titletodisplay, //course.fullCourseNumber,
+        let multipleevents = [];
+        const multipletimeandplace = section.timeLocations;
+        let classinfo = {
+          title: titletodisplay, //course.courseId,
           courseId: course.courseId,
           daysOfWeek: "",
           startTime: "",
@@ -296,23 +295,22 @@ export default {
           enrolledTotal: (section.enrolledTotal ?? section.maxEnroll),
           maxEnroll: section.maxEnroll,
           enrollCode: section.enrollCode,
-          location: section.timeLocations[0].building + " " + section.timeLocations[0].room,
+          location: "",
           instructor: (section.instructors[0]?.instructor ?? "TBA"),
           textColor: "black",
         };
-        for (var k = 0; k < multipletimeandplace.length; k++) {
-          classinfo.daysOfWeek = multipletimeandplace[
-            k
-          ].daysOfWeek.map((a) => dayInt[a]);
+        for (let k = 0; k < multipletimeandplace.length; k++) {
+          classinfo.daysOfWeek = multipletimeandplace[k].fullDays.map((a) => dayInt[a]),
           classinfo.startTime = multipletimeandplace[k].beginTime;
           classinfo.endTime = multipletimeandplace[k].endTime;
-          multipleevents.push(classinfo);
+          classinfo.location = multipletimeandplace[k].building + " " + multipletimeandplace[k].room;
+          multipleevents.push(JSON.parse(JSON.stringify(classinfo)));
         }
         return multipleevents;
       }
     },
     calculateUnits: function (schedule, courses) {
-      var total = 0;
+      let total = 0;
       schedule.classes.forEach((item) => {
         const course = courses.find(
           (course) => course.courseId == item.courseId
@@ -406,7 +404,7 @@ export default {
       }
     },
     exportPDF() {
-      var component = this.$refs.schedule
+      const component = this.$refs.schedule
 
       html2canvas(component, {imageQuality: 1}).then(function(canvas) {
         let pdf = new jsPDF('l', 'mm', 'a4')

--- a/frontend/src/components/schedules/ScheduleC.vue
+++ b/frontend/src/components/schedules/ScheduleC.vue
@@ -194,9 +194,9 @@ export default {
     let latestEvent;
     calendarApi.getEvents().forEach(function (event) {
       let eventDate = new Date(event.start);
-      var minutes = eventDate.getMinutes();
-      var hours = eventDate.getHours();
-      var eventTime = (60 * hours) + minutes;
+      let minutes = eventDate.getMinutes();
+      let hours = eventDate.getHours();
+      let eventTime = (60 * hours) + minutes;
       if(eventTime < earliestTime) {
         earliestTime = eventTime;
         earliestEvent = event;
@@ -224,7 +224,6 @@ export default {
       const _this = this;
       let incrementalCustomEventId = 0;
       function classSectionToFullCalendarEvent(classSection) {
-
         const course = courses.find(
             (course) => course.courseId == classSection.courseId
         );
@@ -278,10 +277,9 @@ export default {
           .map(createScheduleObject)
           .flat();
 
-
       let totalevents = classes
           .map(classSectionToFullCalendarEvent)
-          .flat(); //do this function to all of the classes
+          .flat(2); //do this function to all of the classes
       let customevents = customEvents.map(
           classSectionToFullCalendarEvent
       );
@@ -298,14 +296,7 @@ export default {
       const section = course.classSections.find(
           (section) => section.enrollCode == enrollcode
       );
-
-      let titletodisplay;
-      if(section.isLecture === true) {
-        titletodisplay = course.fullCourseNumber + ": " + enrollcode;
-      }
-      else {
-        titletodisplay = course.fullCourseNumber + ": " + enrollcode;
-      }
+      let titletodisplay = course.courseId.trim() + ": " + enrollcode;
       const dayInt = {
         MONDAY: 1,
         TUESDAY: 2,
@@ -316,7 +307,7 @@ export default {
       };
       if (section.timeLocations.length == 1) {
         return {
-          title: titletodisplay, //course.fullCourseNumber,
+          title: titletodisplay,
           courseId: course.courseId,
           groupId: enrollcode,
           daysOfWeek: section.timeLocations[0].fullDays.map((a) => dayInt[a]),
@@ -342,7 +333,7 @@ export default {
         let multipleevents = [];
         let multipletimeandplace = section.timeLocations;
         let classinfo = {
-          title: titletodisplay, //course.fullCourseNumber,
+          title: titletodisplay,
           courseId: course.courseId,
           groupId: enrollcode,
           daysOfWeek: "",
@@ -361,17 +352,15 @@ export default {
           enrolledTotal: (section.enrolledTotal ?? section.maxEnroll),
           maxEnroll: section.maxEnroll,
           enrollCode: section.enrollCode,
-          location: section.timeLocations[0].building + " " + section.timeLocations[0].room,
+          location: "",
           instructor: (section.instructors[0]?.instructor ?? "TBA"),
         };
         for (let k = 0; k < multipletimeandplace.length; k++) {
-          classinfo.daysOfWeek = multipletimeandplace[
-              k
-              ].daysOfWeek.map((a) => dayInt[a]);
+          classinfo.daysOfWeek = multipletimeandplace[k].fullDays.map((a) => dayInt[a]);
           classinfo.startTime = multipletimeandplace[k].beginTime;
           classinfo.endTime = multipletimeandplace[k].endTime;
-
-          multipleevents.push(classinfo);
+          classinfo.location = multipletimeandplace[k].building + " " + multipletimeandplace[k].room;
+          multipleevents.push(JSON.parse(JSON.stringify(classinfo)));
         }
         return multipleevents;
       }
@@ -854,7 +843,7 @@ export default {
       }
     },
     exportPDF() {
-      var component = this.$refs.schedule
+      const component = this.$refs.schedule
       html2canvas(component, {imageQuality: 1}).then(function (canvas) {
         let pdf = new jsPDF('l', 'mm', 'a4')
         let imgData = canvas.toDataURL('image/jpeg');

--- a/frontend/tests/unit/components/SelectedEvents.spec.js
+++ b/frontend/tests/unit/components/SelectedEvents.spec.js
@@ -61,7 +61,7 @@ describe('SelectedEvents.vue', () => {
         it('the events are rendered with their names', () => {
             const courses = wrapper.findAll('.selected-course');
             expect(courses.length).toBe(2);
-            expect(courses.at(0).find('.event-name').text()).toBe('DUM 200 (Full)')
+            expect(courses.at(0).find('.event-name').text().substring(0,7)).toBe('DUM 200')
         });
 
         it('the courses are rendered with their titles', () => {


### PR DESCRIPTION
• Popovers now appear for both selected and non-selected courses. 
• Added support for differing subjects in the same department (e.g. ASTRO and PHYS are both subjects under the PHYS department, but ASTRO classes showed up as "PHYS 1", "PHYS 1H", etc.).
• Set default toggles for "full classes" and "grad classes" to true.
• Fixed alignment of "full classes" and "grad classes" checkboxes.
• Filtered out completely cancelled and TBA courses since they do not render/break on calendars (e.g. ANTH 194).
• Fixed rendering of lectures/sections when they have more than one "timelocation" (e.g. ART CS 112).