### PR TITLE
Color picker feature

### DIFF
--- a/backend/src/main/java/org/gaucho/courses/GauchoCoursesApplication.java
+++ b/backend/src/main/java/org/gaucho/courses/GauchoCoursesApplication.java
@@ -21,7 +21,7 @@ public class GauchoCoursesApplication {
 	}
 
 	// Required if embedded mongo does not work on local architecture
-	static { System.setProperty("os.arch", "i686_64"); }
+//	static { System.setProperty("os.arch", "i686_64"); }
 
 	public static void main(String[] args) {
 		SpringApplication.run(GauchoCoursesApplication.class, args);

--- a/backend/src/main/java/org/gaucho/courses/GauchoCoursesApplication.java
+++ b/backend/src/main/java/org/gaucho/courses/GauchoCoursesApplication.java
@@ -21,7 +21,7 @@ public class GauchoCoursesApplication {
 	}
 
 	// Required if embedded mongo does not work on local architecture
-//	static { System.setProperty("os.arch", "i686_64"); }
+	static { System.setProperty("os.arch", "i686_64"); }
 
 	public static void main(String[] args) {
 		SpringApplication.run(GauchoCoursesApplication.class, args);

--- a/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
+++ b/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
@@ -117,7 +117,6 @@ public class ScheduleController {
     @PostMapping(value = "/")
     @Secured("ROLE_USER")
     public ResponseEntity<?> saveSchedule(@RequestBody ScheduleControllerSaveRequest scheduleControllerSaveRequest) {
-        System.out.println(scheduleControllerSaveRequest);
 
         String authenticatedUsersEmail = userController.getUserEmail();
         boolean isCustom = scheduleControllerSaveRequest.getSelectedClassSections() != null;
@@ -206,7 +205,6 @@ public class ScheduleController {
                 .status(HttpStatus.BAD_REQUEST)
                 .body("");
         } else {
-            System.out.println(scheduleRepository.findByUserEmail(authenticatedUsersEmail));
             return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(scheduleRepository.findByUserEmail(authenticatedUsersEmail));

--- a/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
+++ b/backend/src/main/java/org/gaucho/courses/controller/ScheduleController.java
@@ -117,6 +117,7 @@ public class ScheduleController {
     @PostMapping(value = "/")
     @Secured("ROLE_USER")
     public ResponseEntity<?> saveSchedule(@RequestBody ScheduleControllerSaveRequest scheduleControllerSaveRequest) {
+        System.out.println(scheduleControllerSaveRequest);
 
         String authenticatedUsersEmail = userController.getUserEmail();
         boolean isCustom = scheduleControllerSaveRequest.getSelectedClassSections() != null;
@@ -205,6 +206,7 @@ public class ScheduleController {
                 .status(HttpStatus.BAD_REQUEST)
                 .body("");
         } else {
+            System.out.println(scheduleRepository.findByUserEmail(authenticatedUsersEmail));
             return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(scheduleRepository.findByUserEmail(authenticatedUsersEmail));

--- a/backend/src/main/java/org/gaucho/courses/domain/remote/ClassSection.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/remote/ClassSection.java
@@ -32,7 +32,8 @@ import java.util.Map;
         "restrictionMinor",
         "restrictionMinorPass",
         "concurrentCourses",
-        "instructors"
+        "instructors",
+        "backgroundColor"
 })
 @Slf4j
 @Data
@@ -71,6 +72,8 @@ public class ClassSection extends Event implements Serializable {
     public boolean isLecture(){
         return this.getSection().endsWith("00");
     }
+
+    @JsonProperty("backgroundColor")        private String backgroundColor;
 
     public ClassSection() { }
 }

--- a/backend/src/main/java/org/gaucho/courses/domain/remote/CustomEvent.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/remote/CustomEvent.java
@@ -12,8 +12,7 @@ import java.io.Serializable;
 @JsonPropertyOrder({
         "name",
         "timeLocations",
-        "backgroundColor",
-        "borderColor"
+        "backgroundColor"
 })
 @Slf4j
 @Data
@@ -22,7 +21,6 @@ public class CustomEvent extends Event implements Serializable {
 
     @JsonProperty("name") private String name;
     @JsonProperty("backgroundColor")             private String backgroundColor;
-    @JsonProperty("borderColor")                private String borderColor;
 
     public CustomEvent() { }
 }

--- a/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
@@ -1,6 +1,5 @@
 package org.gaucho.courses.domain.scheduling;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;

--- a/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
@@ -1,5 +1,6 @@
 package org.gaucho.courses.domain.scheduling;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -20,4 +21,8 @@ public class CourseAndClassIds implements Serializable {
     List<String> scheduledEnrollCodes = new ArrayList<>();  // ToDo: this should be a set
 
     List<String> selectedEnrollCodes = new ArrayList<>();  // ToDo: this should be a set
+
+    String backgroundColor;
+
+    String borderColor;
 }

--- a/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/scheduling/CourseAndClassIds.java
@@ -12,10 +12,6 @@ public class CourseAndClassIds implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-//    @Id
-//    @GeneratedValue(strategy= GenerationType.AUTO)
-//    Long id;
-
     String courseId;  // ToDo: This should be a HATEOS reference
 
     List<String> scheduledEnrollCodes = new ArrayList<>();  // ToDo: this should be a set
@@ -23,6 +19,4 @@ public class CourseAndClassIds implements Serializable {
     List<String> selectedEnrollCodes = new ArrayList<>();  // ToDo: this should be a set
 
     String backgroundColor;
-
-    String borderColor;
 }

--- a/backend/src/main/java/org/gaucho/courses/domain/scheduling/Schedule.java
+++ b/backend/src/main/java/org/gaucho/courses/domain/scheduling/Schedule.java
@@ -110,10 +110,12 @@ public class Schedule implements Serializable {
                     .findFirst();
             if (maybe.isPresent()) {
                 maybe.get().scheduledEnrollCodes.add(section.getEnrollCode());
+                maybe.get().backgroundColor = section.getBackgroundColor();
             } else {
                 CourseAndClassIds ids = new CourseAndClassIds();
                 ids.courseId = section.getCourseId();
                 ids.scheduledEnrollCodes.add(section.getEnrollCode());
+                ids.backgroundColor = section.getBackgroundColor();
                 this.classes.add(ids);
             }
         });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "jspdf": "^2.5.1",
         "sass": "^1.56.1",
         "sass-loader": "^8.0.0",
+        "verte": "^0.0.12",
         "vue": "^2.6.10",
         "vue-application-insights": "^1.0.7",
         "vue-dayjs-plugin": "^1.0.0",
@@ -6157,6 +6158,11 @@
       "dependencies": {
         "color-name": "1.1.3"
       }
+    },
+    "node_modules/color-fns": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/color-fns/-/color-fns-0.0.10.tgz",
+      "integrity": "sha512-QFKowTE9CXCLp09Gz5cQo8VPUP55hf73iHEI52JC3NyKfMpQG2VoLWmTxYeTKH6ngkEnoMrCdEX//M6J4PVQBA=="
     },
     "node_modules/color-name": {
       "version": "1.1.3",
@@ -17677,6 +17683,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/verte": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/verte/-/verte-0.0.12.tgz",
+      "integrity": "sha512-QEWpKkjAT8SLkNJzeiZxN7tJuUiTTFO51tg9dGIrkDlQhzbaM+bTT0wtDM2c/F+Ur9luE64qhsM4xI0Af3Ut1g==",
+      "dependencies": {
+        "color-fns": "^0.0.10"
+      }
+    },
     "node_modules/vue": {
       "version": "2.7.14",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
@@ -23482,6 +23496,11 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-fns": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/color-fns/-/color-fns-0.0.10.tgz",
+      "integrity": "sha512-QFKowTE9CXCLp09Gz5cQo8VPUP55hf73iHEI52JC3NyKfMpQG2VoLWmTxYeTKH6ngkEnoMrCdEX//M6J4PVQBA=="
     },
     "color-name": {
       "version": "1.1.3",
@@ -32115,6 +32134,14 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
+    },
+    "verte": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/verte/-/verte-0.0.12.tgz",
+      "integrity": "sha512-QEWpKkjAT8SLkNJzeiZxN7tJuUiTTFO51tg9dGIrkDlQhzbaM+bTT0wtDM2c/F+Ur9luE64qhsM4xI0Af3Ut1g==",
+      "requires": {
+        "color-fns": "^0.0.10"
+      }
     },
     "vue": {
       "version": "2.7.14",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "flush-promises": "^1.0.2",
         "fullcalendar": "^6.1.4",
         "html2canvas": "^1.4.1",
+        "jest-canvas-mock": "^2.4.0",
         "jest-transform-css": "^6.0.0",
         "jquery": "^3.5.0",
         "jspdf": "^2.5.1",
@@ -6939,6 +6940,11 @@
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg=="
+    },
     "node_modules/cssnano": {
       "version": "5.1.14",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
@@ -10315,6 +10321,15 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "node_modules/jest-changed-files": {
@@ -13885,6 +13900,19 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==",
       "dev": true
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
@@ -18056,9 +18084,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -24093,6 +24121,11 @@
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg=="
+    },
     "cssnano": {
       "version": "5.1.14",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
@@ -26602,6 +26635,15 @@
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
         "jest-cli": "^27.5.1"
+      }
+    },
+    "jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "jest-changed-files": {
@@ -29349,6 +29391,21 @@
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==",
       "dev": true
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "mrmime": {
       "version": "1.0.1",
@@ -32437,9 +32494,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "jspdf": "^2.5.1",
     "sass": "^1.56.1",
     "sass-loader": "^8.0.0",
+    "verte": "^0.0.12",
     "vue": "^2.6.10",
     "vue-application-insights": "^1.0.7",
     "vue-dayjs-plugin": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "flush-promises": "^1.0.2",
     "fullcalendar": "^6.1.4",
     "html2canvas": "^1.4.1",
+    "jest-canvas-mock": "^2.4.0",
     "jest-transform-css": "^6.0.0",
     "jquery": "^3.5.0",
     "jspdf": "^2.5.1",

--- a/frontend/src/components/backend-api.js
+++ b/frontend/src/components/backend-api.js
@@ -69,8 +69,9 @@ export default {
      * @param {object} schedule The schedule to save
      */
     saveSchedule(schedule, customEvents, selectedClassSections, scheduledClassSections) {
+        console.log(JSON.stringify(schedule));
         let savableSchedule = {"selectedClassSections": selectedClassSections, "scheduledClassSections": scheduledClassSections, "customEvents": customEvents, "schedule": schedule};
-        return axios_instance.post('/api/schedules/', savableSchedule,)
+        return axios_instance.post('/api/schedules/', savableSchedule)
     },
     /**
      * Gets the schedules for the specified user email address.

--- a/frontend/src/components/events/ListItems/CourseListItem.vue
+++ b/frontend/src/components/events/ListItems/CourseListItem.vue
@@ -62,7 +62,9 @@ export default {
      */
     backgroundColor: function() {
       // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
-      return getBackgroundColor(this.course.courseId.slice(7, 14));
+      let ctx = document.createElement('canvas').getContext('2d');
+      ctx.fillStyle = getBackgroundColor(this.course.courseId.slice(7, 14));
+      return ctx.fillStyle;
     },
     /**
      * Returns whether or not a course is completely full

--- a/frontend/src/components/events/ListItems/CourseListItem.vue
+++ b/frontend/src/components/events/ListItems/CourseListItem.vue
@@ -64,7 +64,7 @@ export default {
     backgroundColor: function() {
       // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
       let ctx = document.createElement('canvas').getContext('2d');
-      ctx.fillStyle = getBackgroundColor(this.course.courseId.replace(/\s/g, ""));
+      ctx.fillStyle = getBackgroundColor(this.course.courseId);
       return ctx.fillStyle;
     },
     /**

--- a/frontend/src/components/events/ListItems/CourseListItem.vue
+++ b/frontend/src/components/events/ListItems/CourseListItem.vue
@@ -5,6 +5,7 @@
     :backgroundColor="backgroundColor"
     :full="full"
     :randomId="randomId"
+    :custom=false
   >
     <template v-slot:subtext>
       <strong>{{ displayUnits }}</strong>
@@ -63,7 +64,7 @@ export default {
     backgroundColor: function() {
       // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
       let ctx = document.createElement('canvas').getContext('2d');
-      ctx.fillStyle = getBackgroundColor(this.course.courseId.slice(7, 14));
+      ctx.fillStyle = getBackgroundColor(this.course.courseId.replace(/\s/g, ""));
       return ctx.fillStyle;
     },
     /**

--- a/frontend/src/components/events/ListItems/CustomEventListItem.vue
+++ b/frontend/src/components/events/ListItems/CustomEventListItem.vue
@@ -1,9 +1,10 @@
 <template>
     <EventListItem
         :title="customEvent.name"
-        :borderColor="customEvent.borderColor"
-        :backgroundColor="customEvent.backgroundColor"
+        :borderColor="borderColor"
+        :backgroundColor="backgroundColor"
         :full=false
+        :custom=true
     >
         <template v-slot:subtext>
             {{days}}
@@ -22,6 +23,7 @@
 <script>
 import EventListItem from "@/components/events/ListItems/EventListItem.vue";
 import {getAbbreviatedDaysForEvent} from "@/components/util/event-methods.js";
+import { getBackgroundColor, getBorderColor } from "@/components/util/color-utils.js";
 
 export default {
   props: {
@@ -31,8 +33,24 @@ export default {
   },
   components: {
     EventListItem
-  }, 
+  },
   computed: {
+    /**
+     * Returns a string with the border color for the event
+     */
+    borderColor: function() {
+      // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
+      return getBorderColor(this.customEvent.name);
+    },
+    /**
+     * Returns a string with the border color for the event
+     */
+    backgroundColor: function() {
+      // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
+      let ctx = document.createElement('canvas').getContext('2d');
+      ctx.fillStyle = getBackgroundColor(this.customEvent.name.replace(/\s/g, ""));
+      return ctx.fillStyle;
+    },
       /**
        * Returns a string with the custom event's days complete with commas.
        */

--- a/frontend/src/components/events/ListItems/CustomEventListItem.vue
+++ b/frontend/src/components/events/ListItems/CustomEventListItem.vue
@@ -48,7 +48,7 @@ export default {
     backgroundColor: function() {
       // TODO: Once we have class definitions on the frontend, consolidate any usages of "getColor" stuff to the class definitions.
       let ctx = document.createElement('canvas').getContext('2d');
-      ctx.fillStyle = getBackgroundColor(this.customEvent.name.replace(/\s/g, ""));
+      ctx.fillStyle = getBackgroundColor(this.customEvent.name);
       return ctx.fillStyle;
     },
       /**

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -1,9 +1,18 @@
 <template>
   <div>
     <b-list-group-item class="d-flex p-0 w-100">
-      <div class="event-color-block"
+      <!-- <div class="event-color-block"
         :style="{'background-color': backgroundColor, 'border-right-color': borderColor }"
-      ></div>
+      ></div> -->
+      <div class="event-color-block" :style="{'border-right-color': borderColor}">
+        <template>
+          <verte :value="backgroundColor" picker="square" menuPosition="center" model="rgb" draggable="false" enableAlpha=true>
+            <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+              <rect width="100%" height="100%"/>
+            </svg>
+          </verte>
+        </template>
+      </div>
       <div class="my-1 ml-2">
         <p class="mb-0">
           <strong class="event-name" v-if="full === false">{{ this.title }}</strong>
@@ -55,7 +64,14 @@ export default {
   color: gray;
   text-decoration: underline;
 }
-
+.verte {
+  width: 100%;
+  height: 100%;
+}
+.verte > .verte__guide {
+  width: 100%;
+  height: 100%;
+}
 .event-color-block {
     width: 5%;
     border-right-width: 2px; 

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -4,8 +4,8 @@
       <div class="event-color-block" :style="{'border-right-color': borderColor}">
         <template>
           <verte v-model="colorVal" :value="backgroundColor" picker="square" menuPosition="center" model="rgb" :enableAlpha="false">
-            <svg :class="'course-id-' + titleHash" viewBox="0 0 1 1" preserveAspectRatio="none">
-              <rect width="100%" height="100%"/>
+            <svg :class="'color-block course-id-' + titleHash" viewBox="0 0 1 1" preserveAspectRatio="none">
+              <rect/>
             </svg>
           </verte>
         </template>
@@ -96,6 +96,13 @@ export default {
   min-width: 0;
   border-right-width: 2px; 
   border-right-style: solid;
+}
+.color-block {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
 }
 .event-description-block {
   min-width: 0;

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -4,7 +4,7 @@
       <div class="event-color-block" :style="{'border-right-color': borderColor}">
         <template>
           <verte v-model="colorVal" :value="backgroundColor" picker="square" menuPosition="center" model="rgb" :enableAlpha="false">
-            <svg :class="'course-id-' + title.replace(/\s/g,'')" viewBox="0 0 1 1" preserveAspectRatio="none">
+            <svg :class="'course-id-' + titleHash" viewBox="0 0 1 1" preserveAspectRatio="none">
               <rect width="100%" height="100%"/>
             </svg>
           </verte>
@@ -35,7 +35,7 @@
 </template>
 
 <script>
-import { setBackgroundColor } from "@/components/util/color-utils.js";
+import { setBackgroundColor, getHash } from "@/components/util/color-utils.js";
 import $ from "jquery";
 
 export default {
@@ -59,6 +59,11 @@ export default {
           type: Boolean
       }
   },
+  computed: {
+    titleHash() {
+      return getHash(this.title)
+    }
+  },
   data: function() {
     return {
       colorVal: this.backgroundColor,
@@ -66,8 +71,8 @@ export default {
   },
   watch: {
     colorVal(color) {
-      setBackgroundColor(this.title.replace(/\s/g, ""), color);
-      $(".course-id-" + this.title.replace(/\s/g,'')).css({'background-color': color, 'fill': color});
+      setBackgroundColor(this.title, color);
+      $(".course-id-" + this.titleHash).css({'background-color': color, 'fill': color});
     }
   },
 }

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -10,7 +10,7 @@
           </verte>
         </template>
       </div>
-      <div class="my-1 ml-2">
+      <div class="event-description-block my-1 ml-2">
         <p class="mb-0">
           <strong class="event-name" v-if="full === false">{{ this.title }}</strong>
           <strong class="event-name" v-else>{{ this.title }} (Full)</strong>
@@ -22,7 +22,7 @@
           </small>
         </span>
       </div>
-      <div class="ml-auto mr-4 align-self-center">
+      <div class="event-button-block align-self-center">
           <slot name="buttons">
           </slot>
       </div>
@@ -67,15 +67,6 @@ export default {
   watch: {
     colorVal(color) {
       setBackgroundColor(this.title.replace(/\s/g, ""), color);
-
-      // const addStyle = (() => {
-      //   const style = document.createElement('style');
-      //   document.head.append(style);
-      //   return (styleString) => style.textContent = styleString;
-      // })();
-
-      // addStyle('.course-id-' + this.title.replace(/\s/g,'') + '{background-color:' + color + '; fill:' + color + '}');
-
       $(".course-id-" + this.title.replace(/\s/g,'')).css({'background-color': color, 'fill': color});
     }
   },
@@ -96,8 +87,18 @@ export default {
   height: 100%;
 }
 .event-color-block {
-    width: 5%;
-    border-right-width: 2px; 
-    border-right-style: solid;
+  flex-basis: 5%;
+  min-width: 0;
+  border-right-width: 2px; 
+  border-right-style: solid;
+}
+.event-description-block {
+  min-width: 0;
+  flex-basis: 80%;
+}
+.event-button-block {
+  min-width: 0;
+  text-align: center;
+  flex-basis: 15%;
 }
 </style>

--- a/frontend/src/components/events/ListItems/EventListItem.vue
+++ b/frontend/src/components/events/ListItems/EventListItem.vue
@@ -1,13 +1,10 @@
 <template>
   <div>
     <b-list-group-item class="d-flex p-0 w-100">
-      <!-- <div class="event-color-block"
-        :style="{'background-color': backgroundColor, 'border-right-color': borderColor }"
-      ></div> -->
       <div class="event-color-block" :style="{'border-right-color': borderColor}">
         <template>
-          <verte :value="backgroundColor" picker="square" menuPosition="center" model="rgb" draggable="false" enableAlpha=true>
-            <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+          <verte v-model="colorVal" :value="backgroundColor" picker="square" menuPosition="center" model="rgb" :enableAlpha="false">
+            <svg :class="'course-id-' + title.replace(/\s/g,'')" viewBox="0 0 1 1" preserveAspectRatio="none">
               <rect width="100%" height="100%"/>
             </svg>
           </verte>
@@ -38,24 +35,50 @@
 </template>
 
 <script>
+import { setBackgroundColor } from "@/components/util/color-utils.js";
+import $ from "jquery";
+
 export default {
-    props: {
-        title: {
-            type: String
-        },
-        backgroundColor: {
-            type: String
-        },
-        borderColor: {
-            type: String
-        },
-        full: {
-            type: Boolean
-        },
-        randomId: {
-            type: String
-        }
+  props: {
+      title: {
+          type: String
+      },
+      backgroundColor: {
+          type: String
+      },
+      borderColor: {
+          type: String
+      },
+      full: {
+          type: Boolean
+      },
+      randomId: {
+          type: String
+      },
+      custom: {
+          type: Boolean
+      }
+  },
+  data: function() {
+    return {
+      colorVal: this.backgroundColor,
+    };
+  },
+  watch: {
+    colorVal(color) {
+      setBackgroundColor(this.title.replace(/\s/g, ""), color);
+
+      // const addStyle = (() => {
+      //   const style = document.createElement('style');
+      //   document.head.append(style);
+      //   return (styleString) => style.textContent = styleString;
+      // })();
+
+      // addStyle('.course-id-' + this.title.replace(/\s/g,'') + '{background-color:' + color + '; fill:' + color + '}');
+
+      $(".course-id-" + this.title.replace(/\s/g,'')).css({'background-color': color, 'fill': color});
     }
+  },
 }
 </script>
 

--- a/frontend/src/components/events/SelectedEvents.vue
+++ b/frontend/src/components/events/SelectedEvents.vue
@@ -150,10 +150,8 @@ export default {
     height: 100%;
 }
 
-.event-color-block {
-    width: 5%;
-    border-right-width: 2px;
-    border-right-style: solid;
+.edit-event {
+    margin-right: 0.2rem;
 }
 
 #addCustomEventIcon:hover {

--- a/frontend/src/components/events/SelectedEvents.vue
+++ b/frontend/src/components/events/SelectedEvents.vue
@@ -14,23 +14,22 @@
             no-body
             style="height: 100%"
         >
-        <template v-slot:header>
-          <b class="float-left mt-1">Selected Courses</b>
-          <div id="conflictingEventIcon" class="ml-2 mb-0">
-            <font-awesome-icon
-              v-if="$store.getters.selectionsAreConflicting"
-              size="lg"
-              icon='info-circle'
-              :style="{ color: 'red' }"/>
-            <b-tooltip target="conflictingEventIcon">Some of your chosen lectures are conflicting! Click the edit button to deselect the conflicting lecture(s).</b-tooltip>
-          </div>
-          <a @click="$eventHub.$emit('start-new-custom-course', 0)">
-              <div id="addCustomEventIcon" class="float-right add-event-button-outline">
-                  <font-awesome-icon icon="calendar-plus"/>
-                  <small class="ml-1" for="addCustomEventIcon">Add custom event</small>
-                  <b-tooltip target="addCustomEventIcon">Add custom event</b-tooltip>
-              </div>
-          </a>
+        <template>
+            <div id="selected-courses-header" class="card-header">
+                <div id="selected-courses-title"><b>Selected Courses</b></div>
+                <div id="conflictingEventIcon">
+                    <font-awesome-icon
+                    v-if="$store.getters.selectionsAreConflicting"
+                    icon='info-circle'
+                    :style="{ color: 'red' }"/>
+                    <b-tooltip target="conflictingEventIcon">Some of your chosen lectures are conflicting! Click the edit button to deselect the conflicting lecture(s).</b-tooltip>
+                </div>
+                <div @click="$eventHub.$emit('start-new-custom-course', 0)" id="addCustomEventIcon" class="float-right add-event-button-outline">
+                    <font-awesome-icon icon="calendar-plus"/>
+                    <small style="margin-left: 3px" for="addCustomEventIcon">Custom</small>
+                    <b-tooltip target="addCustomEventIcon">Add custom event</b-tooltip>
+                </div>
+            </div>
         </template>
         <div class="event-card-body" >
             <template v-if="$store.state.selectedCourses.length == 0 & $store.state.selectedCustomEvents.length == 0">
@@ -154,11 +153,24 @@ export default {
     margin-right: 0.2rem;
 }
 
+#selected-courses-header {
+    padding: 10px 6px 10px 5px;
+}
+
 #addCustomEventIcon:hover {
     cursor: pointer;
 }
 
+#addCustomEventIcon, #conflictingEventIcon, #selected-courses-title {
+    display: inline-block;
+}
+
+#selected-courses-title {
+    padding-right: 3px;
+}
+
 .add-event-button-outline {
+    margin-top: -2px;
     border-style: solid;
     border-color: rgba(44, 62, 80, 0.75);
     border-width: 1px;

--- a/frontend/src/components/schedules/BuilderView.vue
+++ b/frontend/src/components/schedules/BuilderView.vue
@@ -4,6 +4,8 @@
         cols="12"
         :md="12">
       <ScheduleC
+        v-if="(this.$store.state.selectedCustomEvents.length + this.$store.state.selectedCourses.length) != 0"
+        :key="this.$store.state.selectedCustomEvents.length + this.$store.state.selectedCourses.length"
         :customEvents="$store.state.selectedCustomEvents"
         :courses="$store.state.selectedCourses"
         :conflicting="conflicting"
@@ -25,6 +27,10 @@ export default {
     },
     conflicting: {
       type: Boolean,
+      required: false,
+    },
+    numberSelectedEvents: {
+      type: Number,
       required: false,
     }
   },

--- a/frontend/src/components/schedules/Schedule.vue
+++ b/frontend/src/components/schedules/Schedule.vue
@@ -107,6 +107,7 @@ import api from "@/components/backend-api.js";
 import {
   getBackgroundColor,
   getBorderColor,
+  getHash
 } from "@/components/util/color-utils.js";
 import xss from "xss";
 import { Tooltip } from "bootstrap";
@@ -233,10 +234,11 @@ export default {
             ),
             startTime: classSection.timeLocations[0].beginTime,
             endTime: classSection.timeLocations[0].endTime,
-            color: backgroundColor,
+            borderColor: "black",
+            backgroundColor: backgroundColor,
             isLecture: 0,
             textColor: "black",
-            className: "selected-event" + (!_this.onUserProfile ? (" course-id-" + classSection.name.replace(/\s/g,'')) : '')
+            className: "selected-event" + (!_this.onUserProfile ? (" course-id-" + getHash(classSection.name)) : '')
           };
         } else {
           return classSection.scheduledEnrollCodes.map((section) =>
@@ -289,7 +291,7 @@ export default {
           location: section.timeLocations[0].building + " " + section.timeLocations[0].room,
           instructor: (section.instructors[0]?.instructor ?? "TBA"),
           textColor: "black",
-          className: "selected-event" + (!this.onUserProfile ? (" course-id-" + course.courseId.replace(/\s/g,'')) : '')
+          className: "selected-event" + (!this.onUserProfile ? (" course-id-" + getHash(course.courseId)) : '')
         };
       } else {
         let multipleevents = [];
@@ -310,7 +312,7 @@ export default {
           location: "",
           instructor: (section.instructors[0]?.instructor ?? "TBA"),
           textColor: "black",
-          className: "selected-event" + !this.onUserProfile ? " course-id-" + course.courseId.replace(/\s/g,'') : ''
+          className: "selected-event" + !this.onUserProfile ? " course-id-" + getHash(course.courseId) : ''
         };
         for (let k = 0; k < multipletimeandplace.length; k++) {
           classinfo.daysOfWeek = multipletimeandplace[k].fullDays.map((a) => dayInt[a]),

--- a/frontend/src/components/schedules/Schedule.vue
+++ b/frontend/src/components/schedules/Schedule.vue
@@ -403,7 +403,6 @@ export default {
       api
         .updateScheduleName(this.schedule.id, this.scheduleName)
         .then(() =>{
-          // this.schedule.name = this.scheduleName;
           this.scheduleLocal.name = this.scheduleName;
         })
         .catch((error) => {
@@ -451,9 +450,6 @@ export default {
 </script>
 
 <style>
-/*@import "~@fullcalendar/core/main.css";*/
-/*@import "~@fullcalendar/timegrid/main.css";*/
-/*@import "~@fullcalendar/daygrid/main.css";*/
 
 .fc-col-header-cell-cushion {
   color: #2c3e50;

--- a/frontend/src/components/schedules/ScheduleC.vue
+++ b/frontend/src/components/schedules/ScheduleC.vue
@@ -247,14 +247,13 @@ export default {
             startTime: classSection.timeLocations[0].beginTime,
             endTime: classSection.timeLocations[0].endTime,
             color: getBackgroundColor(classSection.name),
-            className: 'unselected',
+            className: 'unselected course-id-' + classSection.name.replace(/\s/g,''),
             isLecture: 0,
             lectureSectionGroup: '',
             overlaid: [],
             sectionSelected: false,
             relatedSelected: false,
             textColor: "black",
-
           };
         } else {
           return classSection.selectedEnrollCodes.map((section) =>
@@ -314,8 +313,8 @@ export default {
           startTime: section.timeLocations[0].beginTime,
           endTime: section.timeLocations[0].endTime,
           borderColor: getBorderColor(course.deptCode),
-          backgroundColor: getBackgroundColor(course.courseId.slice(7, 14)),
-          className: 'unselected',
+          backgroundColor: getBackgroundColor(course.courseId),
+          className: 'unselected course-id-' + course.courseId.replace(/\s/g,''),
           isLecture: section.isLecture ? 2 : 1,
           sectionSelected: false,
           overlaid: [],
@@ -340,8 +339,8 @@ export default {
           startTime: "",
           endTime: "",
           borderColor: getBorderColor(course.deptCode),
-          backgroundColor: getBackgroundColor(course.courseId.slice(7, 14)),
-          className: 'unselected',
+          backgroundColor: getBackgroundColor(course.courseId),
+          className: 'unselected course-id-' + course.courseId.replace(/\s/g,''),
           isLecture: section.isLecture ? 2 : 1,
           textColor: "black",
           sectionSelected: false,
@@ -373,8 +372,7 @@ export default {
       if(arg.event.borderColor != "blue") { //If it is being selected
         if(arg.event.extendedProps.isLecture === 2) { //If Lecture
           arg.event.setProp( 'borderColor', 'blue' );
-          arg.event.setProp('classNames', ['selected']);
-
+          arg.event.setProp('classNames', ['selected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
           this.selectedEvents.push(arg.event);
           calendarApi.getEvents().forEach(event => { //Loop through each event in calendar
             if(arg.event.title.substring(0, arg.event.title.indexOf(":")) === event.title.substring(0, event.title.indexOf(":"))) {
@@ -388,7 +386,7 @@ export default {
                 this.selectedEvents.push(event);
                 calendarApi.getEvents().forEach(function (eventTwo) {
                   if(eventTwo.groupId !== event.groupId && new Date(eventTwo.start).getTime() < new Date(event.end).getTime() && new Date(eventTwo.end).getTime() > new Date(event.start).getTime()) { //Get rid of all overlapping events for this lecture AND CHECK IF IT IS ON THE SAME DATE
-                    eventTwo.setProp( 'display', 'none' );
+                    eventTwo.setProp('display', 'none');
                     if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                       concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                     }
@@ -401,7 +399,7 @@ export default {
             }
             //Get rid of all overlapping events for this lecture
             if(event.groupId !== arg.event.groupId && new Date(event.start).getTime() < new Date(arg.event.end).getTime() && new Date(event.end).getTime() > new Date(arg.event.start).getTime()) {
-              event.setProp( 'display', 'none' );
+              event.setProp('display', 'none');
               if(!concurrentLectureSectionGroups.includes(event.extendedProps.lectureSectionGroup)) {
                 concurrentLectureSectionGroups.push(event.extendedProps.lectureSectionGroup);
               }
@@ -415,24 +413,24 @@ export default {
 
         else if (arg.event.extendedProps.isLecture === 1) { //If Section
           arg.event.setProp( 'borderColor', 'blue' );
-          arg.event.setProp('classNames', ['selected']);
+          arg.event.setProp('classNames', ['selected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
           this.selectedEvents.push(arg.event);
           calendarApi.getEvents().forEach(event => { //Loop through each event in calendar
             if(arg.event.title.substring(0, arg.event.title.indexOf(":")) === event.title.substring(0, event.title.indexOf(":"))) { //If the same course
               //Get rid of all similar courses
               if(event.extendedProps.lectureSectionGroup != arg.event.extendedProps.lectureSectionGroup) {
                 event.setExtendedProp('relatedSelected', true);
-                event.setProp( 'display', 'none' );
+                event.setProp('display', 'none');
               }
               else if(event.extendedProps.isLecture === 2) { //If it's part of the same course, lecturesection group, and it is this lecture, select it
                 if(event.borderColor != 'blue') {
                   event.setProp('borderColor', 'blue');
-                  event.setProp('classNames', ['selected']);
+                  event.setProp('classNames', ['selected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
                   this.selectedEvents.push(event);
                 }
                 calendarApi.getEvents().forEach(function (eventTwo) { //get rid of all overlapping events of the lectures
                   if(eventTwo.groupId !== event.groupId && new Date(eventTwo.start).getTime() < new Date(event.end).getTime() && new Date(eventTwo.end).getTime() > new Date(event.start).getTime()) { //Get rid of all overlapping events for this lecture AND CHECK IF IT IS ON THE SAME DATE
-                    eventTwo.setProp( 'display', 'none' );
+                    eventTwo.setProp('display', 'none');
                     if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                       concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                     }
@@ -451,7 +449,7 @@ export default {
                   this.selectedEvents.push(event);
                   calendarApi.getEvents().forEach(function (eventTwo) { //get rid of all overlapping events of the lectures
                     if(eventTwo.groupId !== event.groupId && new Date(eventTwo.start).getTime() < new Date(event.end).getTime() && new Date(eventTwo.end).getTime() > new Date(event.start).getTime()) { //Get rid of all overlapping events for this lecture AND CHECK IF IT IS ON THE SAME DATE
-                      eventTwo.setProp( 'display', 'none' );
+                      eventTwo.setProp('display', 'none');
                       if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                         concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                       }
@@ -464,7 +462,7 @@ export default {
               }
             }
             if(event.groupId !== arg.event.groupId && new Date(event.start).getTime() < new Date(arg.event.end).getTime() && new Date(event.end).getTime() > new Date(arg.event.start).getTime()) { //Get rid of all overlapping events for this section
-              event.setProp( 'display', 'none' );
+              event.setProp('display', 'none');
               if(!concurrentLectureSectionGroups.includes(event.extendedProps.lectureSectionGroup)) {
                 concurrentLectureSectionGroups.push(event.extendedProps.lectureSectionGroup);
               }
@@ -477,7 +475,7 @@ export default {
 
         else { //If CustomEvent
           arg.event.setProp( 'borderColor', 'blue' );
-          arg.event.setProp('classNames', ['selected']);
+          arg.event.setProp('classNames', ['selected', 'course-id-' + arg.event.title.replace(/\s/g,'')]);
           this.selectedEvents.push(arg.event);
           calendarApi.getEvents().forEach(function (event) { //Loop through each event in calendar
             if(event.groupId !== arg.event.groupId && new Date(event.start).getTime() < new Date(arg.event.end).getTime() && new Date(event.end).getTime() > new Date(arg.event.start).getTime()) { //Get rid of all overlapping events for this customevent
@@ -541,13 +539,13 @@ export default {
               (course) => course.courseId == arg.event.extendedProps.courseId
           );
           arg.event.setProp('borderColor', getBorderColor(course.deptCode));
-          arg.event.setProp('classNames', ['unselected']);
+          arg.event.setProp('classNames', ['unselected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
           calendarApi.getEvents().forEach(event => { //Loop through each event in calendar
             if(arg.event.title.substring(0, arg.event.title.indexOf(":")) === event.title.substring(0, event.title.indexOf(":"))) { //If it's the same course
               if(event.extendedProps.isLecture === 1 && event.borderColor == "blue") { //deselect the selected sections for this lecture and then show all sections
                 event.setProp('borderColor', getBorderColor(course.deptCode));
-                event.setProp('classNames', ['unselected']);
+                event.setProp('classNames', ['unselected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
                 this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != event.groupId);
                 calendarApi.getEvents().forEach(function (eventTwo) { //Adds all overlapping events of section
                   if(eventTwo.groupId !== event.groupId && new Date(eventTwo.start).getTime() < new Date(event.end).getTime() && new Date(eventTwo.end).getTime() > new Date(event.start).getTime()) {
@@ -556,6 +554,7 @@ export default {
                     }));
                     if(eventTwo.extendedProps.sectionSelected == false && eventTwo.extendedProps.relatedSelected == false && eventTwo.extendedProps.overlaid.length === 0) {
                       eventTwo.setProp('display', 'auto')
+                      eventTwo.setProp('backgroundColor', eventTwo.extendedProps.courseId != "none" ? getBackgroundColor(eventTwo.title.slice(0, eventTwo.title.indexOf(":"))) : getBackgroundColor(eventTwo.title));
                       if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                         concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                       }
@@ -568,6 +567,7 @@ export default {
               event.setExtendedProp('sectionSelected', false);
               if(event.extendedProps.overlaid.length === 0) {
                 event.setProp('display', 'auto');
+                event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : getBackgroundColor(event.title));
               }
             }
             if(event.groupId === arg.event.groupId && new Date(event.start).getTime() != new Date(arg.event.start).getTime()) { //For the other lectures events that become unselected, show their concurrent events
@@ -578,6 +578,7 @@ export default {
                   }));
                   if (eventTwo.extendedProps.sectionSelected == false && eventTwo.extendedProps.relatedSelected == false && eventTwo.extendedProps.overlaid.length === 0) {
                     eventTwo.setProp('display', 'auto');
+                    eventTwo.setProp('backgroundColor', eventTwo.extendedProps.courseId != "none" ? getBackgroundColor(eventTwo.title.slice(0, eventTwo.title.indexOf(":"))) : getBackgroundColor(eventTwo.title));
                     if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                       concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                     }
@@ -591,6 +592,7 @@ export default {
               }));
               if (event.extendedProps.sectionSelected == false && event.extendedProps.relatedSelected == false && event.extendedProps.overlaid.length === 0) {
                 event.setProp('display', 'auto');
+                event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : getBackgroundColor(event.title));
                 if(!concurrentLectureSectionGroups.includes(event.extendedProps.lectureSectionGroup)) {
                   concurrentLectureSectionGroups.push(event.extendedProps.lectureSectionGroup);
                 }
@@ -605,14 +607,14 @@ export default {
               (course) => course.courseId == arg.event.extendedProps.courseId
           );
           arg.event.setProp('borderColor', getBorderColor(course.deptCode));
-          arg.event.setProp('classNames', ['unselected']);
-
+          arg.event.setProp('classNames', ['unselected', 'course-id-' + arg.event.title.substring(0, arg.event.title.indexOf(":")).replace(/\s/g,'')]);
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
           calendarApi.getEvents().forEach(function (event) { //Loop through each event in calendar
             if(arg.event.title.substring(0, arg.event.title.indexOf(":")) === event.title.substring(0, event.title.indexOf(":")) && event.extendedProps.lectureSectionGroup == arg.event.extendedProps.lectureSectionGroup && event.extendedProps.isLecture === 1) { //If the same course, same lectureSectionGroup, and it is a section, show it
               event.setExtendedProp('sectionSelected', false);
               if(event.extendedProps.overlaid.length === 0) {
                 event.setProp('display', 'auto');
+                event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : getBackgroundColor(event.title));
               }
             }
             if(event.groupId === arg.event.groupId && new Date(event.start).getTime() != new Date(arg.event.start).getTime()) {
@@ -623,6 +625,7 @@ export default {
                   }));
                   if(eventTwo.extendedProps.sectionSelected == false && eventTwo.extendedProps.relatedSelected == false && eventTwo.extendedProps.overlaid.length === 0) {
                     eventTwo.setProp('display', 'auto');
+                    eventTwo.setProp('backgroundColor', eventTwo.extendedProps.courseId != "none" ? getBackgroundColor(eventTwo.title.slice(0, eventTwo.title.indexOf(":"))) : eventTwo.title);
                     if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                       concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                     }
@@ -636,6 +639,7 @@ export default {
               }));
               if(event.extendedProps.sectionSelected == false && event.extendedProps.relatedSelected == false && event.extendedProps.overlaid.length === 0) {
                 event.setProp('display', 'auto');
+                event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : getBackgroundColor(event.title));
                 if(!concurrentLectureSectionGroups.includes(event.extendedProps.lectureSectionGroup)) {
                   concurrentLectureSectionGroups.push(event.extendedProps.lectureSectionGroup);
                 }
@@ -646,7 +650,7 @@ export default {
 
         else { //If Custom Event
           arg.event.setProp( 'borderColor', 'transparent');
-          arg.event.setProp('classNames', ['unselected']);
+          arg.event.setProp('classNames', ['unselected', 'course-id-' + arg.event.title.replace(/\s/g,'')]);
 
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
           calendarApi.getEvents().forEach(function (event) { //Loop through each event in calendar
@@ -658,6 +662,7 @@ export default {
                   }));
                   if(eventTwo.extendedProps.sectionSelected == false && eventTwo.extendedProps.relatedSelected == false && eventTwo.extendedProps.overlaid.length === 0) {
                     eventTwo.setProp('display', 'auto');
+                    eventTwo.setProp('backgroundColor', eventTwo.extendedProps.courseId != "none" ? getBackgroundColor(eventTwo.title.slice(0, eventTwo.title.indexOf(":"))) : getBackgroundColor(eventTwo.title));
                     if(!concurrentLectureSectionGroups.includes(eventTwo.extendedProps.lectureSectionGroup)) {
                       concurrentLectureSectionGroups.push(eventTwo.extendedProps.lectureSectionGroup);
                     }
@@ -671,6 +676,7 @@ export default {
               }));
               if(event.extendedProps.sectionSelected == false && event.extendedProps.relatedSelected == false && event.extendedProps.overlaid.length === 0) {
                 event.setProp('display', 'auto');
+                event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : event.title);
                 if(!concurrentLectureSectionGroups.includes(event.extendedProps.lectureSectionGroup)) {
                   concurrentLectureSectionGroups.push(event.extendedProps.lectureSectionGroup);
                 }
@@ -701,6 +707,7 @@ export default {
               calendarApi.getEvents().forEach(event => {
                 if (event.extendedProps.lectureSectionGroup === concurrentLectureSectionGroups[k] && event.extendedProps.sectionSelected == false && event.extendedProps.relatedSelected == false && event.extendedProps.overlaid.length === 0) {
                   event.setProp('display', 'auto');
+                  event.setProp('backgroundColor', event.extendedProps.courseId != "none" ? getBackgroundColor(event.title.slice(0, event.title.indexOf(":"))) : getBackgroundColor(event.title));
                   if(event.borderColor == 'blue') {
                     this.selectedEvents.push(event);
                   }
@@ -758,6 +765,7 @@ export default {
                 (customEvent) => customEvent.name == event.title
             );
             if(!customEventsSchedule.find(customEventSchedule => customEventSchedule.name == customEvent.name)) {
+              customEvent.backgroundColor = getBackgroundColor(customEvent.name);
               customEventsSchedule.push(customEvent);
             }
           }
@@ -769,6 +777,7 @@ export default {
 
             course.classSections.forEach(section => { //Add each section of the course to scheduledClassSections
               if(!selectedClassSections.find(selectedClassSection => selectedClassSection.enrollCode == section.enrollCode)) {
+                section.backgroundColor = getBackgroundColor(section.courseId);
                 selectedClassSections.push(section);
               }
             });

--- a/frontend/src/components/schedules/ScheduleC.vue
+++ b/frontend/src/components/schedules/ScheduleC.vue
@@ -373,7 +373,6 @@ export default {
       let concurrentLectureSectionGroups = [];
       if(!arg.event.classNames.includes('selected')) { //If it is being selected
         if(arg.event.extendedProps.isLecture === 2) { //If Lecture
-          // arg.event.setProp( 'borderColor', 'blue' );
           arg.event.setProp('classNames', ['selected', 'course-id-' + getHash(arg.event.title.substring(0, arg.event.title.indexOf(":")))]);
           this.selectedEvents.push(arg.event);
           calendarApi.getEvents().forEach(event => { //Loop through each event in calendar
@@ -426,7 +425,6 @@ export default {
               }
               else if(event.extendedProps.isLecture === 2) { //If it's part of the same course, lecturesection group, and it is this lecture, select it
                 if(!event.classNames.includes('selected')) {
-                  // event.setProp('borderColor', 'blue');
                   event.setProp('classNames', ['selected', 'course-id-' + getHash(arg.event.title.substring(0, arg.event.title.indexOf(":")))]);
                   this.selectedEvents.push(event);
                 }
@@ -476,7 +474,6 @@ export default {
         }
 
         else { //If CustomEvent
-          // arg.event.setProp( 'borderColor', 'blue' );
           arg.event.setProp('classNames', ['selected', 'course-id-' + getHash(arg.event.title)]);
           this.selectedEvents.push(arg.event);
           calendarApi.getEvents().forEach(function (event) { //Loop through each event in calendar
@@ -537,16 +534,11 @@ export default {
       else { //If it is being unselected
 
         if(arg.event.extendedProps.isLecture === 2) { //If Lecture
-          // const course = this.courses.find(
-          //     (course) => course.courseId == arg.event.extendedProps.courseId
-          // );
-          // arg.event.setProp('borderColor', getBorderColor(course.deptCode));
           arg.event.setProp('classNames', ['unselected', 'course-id-' + getHash(arg.event.title.substring(0, arg.event.title.indexOf(":")))]);
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
           calendarApi.getEvents().forEach(event => { //Loop through each event in calendar
             if(arg.event.title.substring(0, arg.event.title.indexOf(":")) === event.title.substring(0, event.title.indexOf(":"))) { //If it's the same course
               if(event.extendedProps.isLecture === 1 && event.classNames.includes('selected')) { //deselect the selected sections for this lecture and then show all sections
-                // event.setProp('borderColor', getBorderColor(course.deptCode));
                 event.setProp('classNames', ['unselected', 'course-id-' + getHash(arg.event.title.substring(0, arg.event.title.indexOf(":")))]);
                 this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != event.groupId);
                 calendarApi.getEvents().forEach(function (eventTwo) { //Adds all overlapping events of section
@@ -604,11 +596,6 @@ export default {
         }
 
         else if (arg.event.extendedProps.isLecture === 1) { //If Section
-
-          // const course = this.courses.find(
-          //     (course) => course.courseId == arg.event.extendedProps.courseId
-          // );
-          // arg.event.setProp('borderColor', getBorderColor(course.deptCode));
           arg.event.setProp('classNames', ['unselected', 'course-id-' + getHash(arg.event.title.substring(0, arg.event.title.indexOf(":")))]);
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
           calendarApi.getEvents().forEach(function (event) { //Loop through each event in calendar
@@ -651,7 +638,6 @@ export default {
         }
 
         else { //If Custom Event
-          // arg.event.setProp( 'borderColor', ' black');
           arg.event.setProp('classNames', ['unselected', 'course-id-' + getHash(arg.event.title)]);
 
           this.selectedEvents = this.selectedEvents.filter(selectedEvent => selectedEvent.groupId != arg.event.groupId);
@@ -802,7 +788,7 @@ export default {
         api
             .saveSchedule(this.schedule, customEventsSchedule, selectedClassSections, scheduledClassSections)
             .then((response) => {
-              this.schedule = response.data; //TODO: test if this works, by seeing if you can delete the schedule after saving it
+              this.schedule = response.data;
               this.scheduleSavedStatus = "successful";
             })
             .catch((error) => {
@@ -840,7 +826,6 @@ export default {
       api
           .updateScheduleName(this.schedule.id, this.scheduleName)
           .then(() =>{
-            // this.schedule.name = this.scheduleName;
             this.scheduleLocal.name = this.scheduleName;
           })
           .catch((error) => {
@@ -906,9 +891,7 @@ export default {
 .fc-title {
   font-size: 11px;
 }
-a:focus {
 
-}
 .tooltip > .tooltip-inner.course-tooltip {
   text-align: left;
   font-size: 9pt;

--- a/frontend/src/components/schedules/ScheduleC.vue
+++ b/frontend/src/components/schedules/ScheduleC.vue
@@ -178,9 +178,8 @@ export default {
         allDaySlot: false,
         initialView: 'timeGridWeek',
         editable: false,
-        eventClick: this.eventClick,
-        eventClassNames: ['unselected']
-      }
+        eventClick: this.eventClick
+        }
     },
     quarter: function () {
       return this.$store.state.selectedQuarter;

--- a/frontend/src/components/schedules/SchedulePaginator.vue
+++ b/frontend/src/components/schedules/SchedulePaginator.vue
@@ -283,6 +283,7 @@
           :schedules="schedulesToRender"
           :numShow="currentView"
           :showEditButton="showEditButton"
+          :onUserProfile="onUserProfile"
           v-else>
         </ScheduleView>
     </b-card>
@@ -323,7 +324,11 @@ export default {
         showEditButton: {
             type: Boolean,
             default: false
-        }
+        },
+        onUserProfile: {
+            type: Boolean,
+            default: false,
+        },
     },
     created: function() {
         // Register event hooks

--- a/frontend/src/components/schedules/SchedulePaginator.vue
+++ b/frontend/src/components/schedules/SchedulePaginator.vue
@@ -302,7 +302,7 @@
           :key="allowConflicting"
           :conflicting="allowConflicting"
         >
-        </BuilderView> <!--:schedules="schedules.length">-->
+        </BuilderView>
         <ListView
           :schedule="this.filteredAndSortedSchedules.slice((this.currentPage-1)*this.currentView, this.currentPage*this.currentView)"
           v-else-if="currentView == 10"

--- a/frontend/src/components/schedules/ScheduleView.vue
+++ b/frontend/src/components/schedules/ScheduleView.vue
@@ -9,6 +9,7 @@
           :schedule="schedule"
           :courses="$store.state.selectedCourses"
           :showEditButton="showEditButton"
+          :onUserProfile="onUserProfile"
           class="mb-4"
         ></Schedule>
       </b-col>
@@ -36,6 +37,10 @@ export default {
       required: false,
     },
     showEditButton: {
+        type: Boolean,
+        default: false
+    },
+    onUserProfile: {
         type: Boolean,
         default: false
     }

--- a/frontend/src/components/util/color-utils.js
+++ b/frontend/src/components/util/color-utils.js
@@ -64,7 +64,8 @@ const borderColors = [
     '#0E5C00',
 ]
 
-function getHash (str) {
+export function getHash (str) {
+    str = str.replace(/\s/g, "");
     var hash = 0;
     if (str == null || str.length == 0) return hash;
     else {
@@ -113,5 +114,6 @@ export function getBorderColor(string) {
  * @param {string} color
  */
 export function setBackgroundColor(string, color) {
+    string = string.replace(/\s/g, "");
     userBackgroundColors[string] = color;
 }

--- a/frontend/src/components/util/color-utils.js
+++ b/frontend/src/components/util/color-utils.js
@@ -1,6 +1,8 @@
 
 // A list of colors that will be used for the event background and border colors. These are
 // chosen such that they show well with black text on top.
+let userBackgroundColors = {}
+
 const backgroundColors = [
     "Aquamarine",
     "Azure",
@@ -90,6 +92,10 @@ function getColor(string, colors) {
  * @param {string} string 
  */
 export function getBackgroundColor(string) {
+    string = string.replace(/\s/g, "");
+    if (string in userBackgroundColors) {
+        return userBackgroundColors[string];
+    }
     return getColor(string, backgroundColors);
 }
 
@@ -99,4 +105,13 @@ export function getBackgroundColor(string) {
  */
 export function getBorderColor(string) {
     return getColor(string, borderColors);
+}
+
+/**
+ * Stores a background color identified by the given string.
+ * @param {string} string 
+ * @param {string} color
+ */
+export function setBackgroundColor(string, color) {
+    userBackgroundColors[string] = color;
 }

--- a/frontend/src/components/util/color-utils.js
+++ b/frontend/src/components/util/color-utils.js
@@ -65,10 +65,10 @@ const borderColors = [
 ]
 
 export function getHash (str) {
-    str = str.replace(/\s/g, "");
     var hash = 0;
     if (str == null || str.length == 0) return hash;
     else {
+        str = str.replace(/\s/g, "");
         for (let i = 0; i < str.length; i++) {
             let char = str.charCodeAt(i);
             hash = ((hash<<5)-hash) + char;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12,6 +12,8 @@ import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 import '@/plugins/Dayjs';
 import VueDayjs from 'vue-dayjs-plugin'
+import Verte from 'verte';
+import 'verte/dist/verte.css';
 
 // Configure font awesome
 library.add(faInfoCircle, faUndo, faFilter, faCalendarPlus, faPlusSquare, faTrashAlt, faEdit, faExclamationCircle, faStar, faHeart, faThumbtack, faBorderAll, faColumns, faCalendar, faList, faChevronRight, faChevronDown, faCheck, faPencilAlt, faChevronUp);
@@ -20,6 +22,8 @@ Vue.component('font-awesome-icon', FontAwesomeIcon);
 
 // Configure Bootstrap-Vue
 Vue.use(BootstrapVue, VueDayjs);
+
+Vue.component(Verte.name, Verte);
 
 // Configure global event hub
 Vue.prototype.$eventHub = new Vue();

--- a/frontend/src/views/UserProfile.vue
+++ b/frontend/src/views/UserProfile.vue
@@ -33,6 +33,7 @@
                                 :showQuarterSelector="true"
                                 :showFavoritesButton="false"
                                 :showEditButton="true"
+                                :onUserProfile="true"
                                 class="h-100"/>
                               </keep-alive>
                             </b-col>

--- a/frontend/tests/unit/components/SelectedEvents.spec.js
+++ b/frontend/tests/unit/components/SelectedEvents.spec.js
@@ -4,6 +4,7 @@ import BootstrapVue from 'bootstrap-vue';
 import { customEvent, courses } from '../../testing-objects';
 import Vuex from "vuex"
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import "jest-canvas-mock";
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);

--- a/frontend/tests/unit/views/UserProfile.spec.js
+++ b/frontend/tests/unit/views/UserProfile.spec.js
@@ -3,7 +3,6 @@ import UserProfile from '@/views/UserProfile.vue';
 import BootstrapVue from 'bootstrap-vue';
 import { axios_instance } from '@/components/backend-api.js';
 import { schedules, userAttributes, quarters} from '../../testing-objects';
-import flushPromises from "flush-promises";
 import { RouterLinkStub } from '@vue/test-utils';
 const MockAdapter = require("axios-mock-adapter");
 

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,5 +1,5 @@
-// const proxy_url = 'https://gauchocourses-app-prod.happybay-98f6635d.westus.azurecontainerapps.io';
-const proxy_url = 'http://localhost:8088';
+const proxy_url = 'https://gauchocourses-app-prod.happybay-98f6635d.westus.azurecontainerapps.io';
+// const proxy_url = 'http://localhost:8088';
 
 // vue.config.js
 module.exports = {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,5 +1,5 @@
-const proxy_url = 'https://gauchocourses-app-prod.happybay-98f6635d.westus.azurecontainerapps.io';
-// const proxy_url = 'http://localhost:8088';
+// const proxy_url = 'https://gauchocourses-app-prod.happybay-98f6635d.westus.azurecontainerapps.io';
+const proxy_url = 'http://localhost:8088';
 
 // vue.config.js
 module.exports = {


### PR DESCRIPTION
Clicking on the colored rectangle next to courses and custom events allows users to choose their own colors. Saved schedules retain the colors that were picked at the time they were saved. Fixed some minor alignment/spacing issues on different browsers. Added an option to allow/disallow conflicts on the schedule builder. Conflicting schedules can still be saved.