### PR TITLE
Deprecate GauchoCourses and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # GauchoCourses
 
-Data Science UCSB's GauchoCourses application is a quarterly course planner that allows students to see possible schedule combinations for the classes they want to take, and save them for when their pass times come around. https://gauchocourses.datascienceucsb.org/#/
-
-See [the Wiki](https://github.com/data-science-ucsb/gauchocourses/wiki) for contribution instructions and reference information. The [backend](backend/) and [frontend](frontend/) directories have their own respective README's with more information.
-
-Having a problem with the app? [Create an issue here](https://github.com/data-science-ucsb/gauchocourses/issues/new).
+Data Science UCSB's GauchoCourses application is a quarterly course planner that allows students to see possible schedule combinations for the classes they want to take, and save them for when their pass times come around.
 
 Made with <3 by Data Science coders.
+
+> [!IMPORTANT]
+>
+> ## GauchoCourses has been deprecated
+>
+> GauchoCourses is no longer actively maintained.
+>
+> Data Science UCSB deprecated this project on **[DEPRECATION DATE]** due to limited usage and no significant web traffic during the preceding six months, while the application continued to require hosting, monitoring, dependency maintenance, credential management, and security oversight.
+>
+> The hosted application will be decommissioned on **[SHUTDOWN DATE]**. After that date, course search, schedule generation, Google sign-in, and access to saved schedules will no longer be available.
+>
+> Users should save or export any schedule information they wish to retain before the shutdown date.
+>
+> This repository will remain available as a read-only archive for historical and educational purposes. The software is provided as-is and will not receive further support, security updates, bug fixes, or compatibility updates.
+


### PR DESCRIPTION
Updated README to reflect deprecation of GauchoCourses and provide important shutdown information.